### PR TITLE
Update GetDetails.php

### DIFF
--- a/PHP/OneTimePayments/Apicalls/GetDetails.php
+++ b/PHP/OneTimePayments/Apicalls/GetDetails.php
@@ -15,7 +15,6 @@ $requestParameters['currency_code']     = $amazonpay_config['currency_code'];
 $requestParameters['seller_note']       = 'Testing PHP SDK Samples';
 $requestParameters['seller_order_id']   = '123456-TestOrder-123456';
 $requestParameters['store_name']        = 'SDK Sample Store Name';
-$requestParameters['seller_order_id']   = '1234-example-order';
 $requestParameters['custom_information']= 'Any custom information';
 $requestParameters['mws_auth_token']    = null; // only non-null if calling API on behalf of someone else
 $requestParameters['amazon_order_reference_id'] = $_POST['orderReferenceId'];


### PR DESCRIPTION
Double $requestParameters['seller_order_id'] definition removed

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
