### PR TITLE
fixes minor Python syntax issue in AmazonPayClient args

### DIFF
--- a/set.html
+++ b/set.html
@@ -171,7 +171,7 @@
 
 client = AmazonPayClient(
     mws_access_key='ACCESS_KEY',
-    mws_secret_key='SECRET_KEY'
+    mws_secret_key='SECRET_KEY',
     merchant_id='MERCHANT_ID',
     sandbox=True,
     region='na',


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
Fixes a missing comma after `mws_secret_key='SECRET_KEY'` argument on the Python code on the "Amazon Pay Simple Checkout" page. 

gh-pages file: https://github.com/amzn/amazon-pay-sdk-samples/blob/86c3591f854df94d88eb3a07c3d7d661cf3ab3f6/set.html#L174

```
lient = AmazonPayClient(
    mws_access_key='ACCESS_KEY',
    mws_secret_key='SECRET_KEY'
    merchant_id='MERCHANT_ID',
    sandbox=True,
    region='na',
    currency_code='USD')
```

Live Page: https://amzn.github.io/amazon-pay-sdk-samples/set.html

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
